### PR TITLE
Enhance alert display functionality with CSS class toggle

### DIFF
--- a/index.css
+++ b/index.css
@@ -1355,11 +1355,14 @@
   padding: 15px 20px;
   border-radius: 15px;
   margin-bottom: 20px;
-  display: flex;
   align-items: center;
   gap: 10px;
   font-weight: 500;
   animation: slideDown 0.5s ease;
+}
+
+.alert.show, .success-alert.show {
+  display: flex;
 }
 
 @keyframes slideDown {

--- a/index.html
+++ b/index.html
@@ -944,10 +944,10 @@
             if (name && emailid && msgContent) {
               saveMessages(name, emailid, msgContent);
 
-              document.querySelector(".alert").style.display = "block";
+              document.querySelector(".alert").classList.add("show");
 
               setTimeout(() => {
-                document.querySelector(".alert").style.display = "none";
+                document.querySelector(".alert").classList.remove("show");
               }, 3000);
 
               document.getElementById("contactForm").reset();


### PR DESCRIPTION
This pull request updates how alert messages are shown and hidden in the UI. Instead of directly toggling the `display` style property in JavaScript, it now uses a `show` CSS class to control visibility, making the code more maintainable and leveraging CSS for presentation logic.

**Alert display improvements:**

* In `index.html`, the alert is now shown and hidden by adding or removing the `show` class, instead of directly setting the `display` style property.
* In `index.css`, the `.alert.show` and `.success-alert.show` selectors are added to apply `display: flex` when the alert is visible, moving display logic to CSS.

resolved issue #21 